### PR TITLE
Allow module to load

### DIFF
--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -982,7 +982,7 @@ static int handle_host_check( int event_type, void *data ) {
 #ifdef USENAGIOS3
     adjust_host_check_attempt_3x(hst,TRUE);
 #endif
-#if defined(USENAEMON) || defined(USENAGIOS4)
+#ifdef USENAEMON
     adjust_host_check_attempt(hst,TRUE);
 #endif
 


### PR DESCRIPTION
This is more to let you know that I'm also working on this. As far as I can tell, the adjust_host_check_attempt() is simply no longer needed in Core 4.4+. That said, I'm still testing the rest of the behavior